### PR TITLE
Iterable Updates

### DIFF
--- a/iterable-extension/build.gradle
+++ b/iterable-extension/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compile (
             'com.amazonaws:aws-lambda-java-core:1.1.0',
             'com.amazonaws:aws-lambda-java-events:1.1.0',
-            'com.mparticle:java-sdk:1.2.0'
+            'com.mparticle:java-sdk:1.4.0'
     )
     compile project(':iterable-java-sdk')
     testCompile('junit:junit:4.12')

--- a/iterable-extension/build.gradle
+++ b/iterable-extension/build.gradle
@@ -1,15 +1,15 @@
 apply plugin: 'java'
 
 repositories {
+    mavenLocal()
     mavenCentral()
-    maven { url "http://maven.mparticle.com/" }
 }
 
 dependencies {
     compile (
             'com.amazonaws:aws-lambda-java-core:1.1.0',
             'com.amazonaws:aws-lambda-java-events:1.1.0',
-            'com.mparticle:java-sdk:1.0.3'
+            'com.mparticle:java-sdk:1.2.0'
     )
     compile project(':iterable-java-sdk')
     testCompile('junit:junit:4.12')

--- a/iterable-extension/src/main/java/com/mparticle/ext/iterable/IterableExtension.java
+++ b/iterable-extension/src/main/java/com/mparticle/ext/iterable/IterableExtension.java
@@ -384,7 +384,7 @@ public class IterableExtension extends MessageProcessor {
     public void processCustomEvent(CustomEvent event) throws IOException {
         TrackRequest request = new TrackRequest(event.getName());
         request.createdAt = (int) (event.getTimestamp() / 1000.0);
-        request.dataFields = event.getAttributes();
+        request.dataFields = attemptTypeConversion(event.getAttributes());
         List<UserIdentity> identities = event.getContext().getUserIdentities();
         if (identities != null) {
             for (UserIdentity identity : identities) {
@@ -405,6 +405,44 @@ public class IterableExtension extends MessageProcessor {
         } else if (!response.isSuccess()) {
             throw new IOException("Error sending custom event to Iterable: HTTP " + response.code());
         }
+    }
+
+    /**
+     * Make a best-effort attempt to coerce the values of each map item to bool, double, int, and string types
+     *
+     * mParticle's API only accepts string, whereas Iterable's API accept different types. By coercing these types,
+     * users of the Iterable API are able to create campaigns, aggregate events, etc.
+     *
+     * @param attributes
+     * @return
+     */
+    private Map<String, Object> attemptTypeConversion(Map<String, String> attributes) {
+        if (attributes == null) {
+            return null;
+        }
+        Map<String, Object> converted = new HashMap<>(attributes.size());
+        attributes.forEach((key,value)-> {
+            if (isEmpty(value)) {
+                converted.put(key, value);
+            } else {
+                if (value.toLowerCase(Locale.US).equals("true") || value.toLowerCase(Locale.US).equals("false")) {
+                    converted.put(key, Boolean.parseBoolean(value));
+                } else {
+                    try {
+                        double doubleValue = Double.parseDouble(value);
+                        if ((doubleValue % 1) == 0) {
+                            converted.put(key, Integer.parseInt(value));
+                        } else {
+                            converted.put(key, doubleValue);
+                        }
+                    }catch (NumberFormatException nfe) {
+                        converted.put(key, value);
+                    }
+                }
+            }
+
+        });
+        return converted;
     }
 
 

--- a/iterable-extension/src/main/java/com/mparticle/ext/iterable/IterableLambdaEndpoint.java
+++ b/iterable-extension/src/main/java/com/mparticle/ext/iterable/IterableLambdaEndpoint.java
@@ -1,6 +1,7 @@
 package com.mparticle.ext.iterable;
 
 import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.LambdaLogger;
 import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
 import com.mparticle.sdk.model.Message;
 import com.mparticle.sdk.model.MessageSerializer;
@@ -9,10 +10,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
-/**
- * Sample AWS Lambda Endpoint
- */
+
 public class IterableLambdaEndpoint implements RequestStreamHandler {
+
     MessageSerializer serializer = new MessageSerializer();
 
     @Override

--- a/iterable-extension/src/test/java/com/mparticle/ext/iterable/IterableExtensionTest.java
+++ b/iterable-extension/src/test/java/com/mparticle/ext/iterable/IterableExtensionTest.java
@@ -1,6 +1,6 @@
 package com.mparticle.ext.iterable;
 
-import com.amazonaws.util.json.JSONObject;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mparticle.iterable.*;
 import com.mparticle.sdk.model.audienceprocessing.Audience;
 import com.mparticle.sdk.model.audienceprocessing.AudienceMembershipChangeRequest;
@@ -133,7 +133,7 @@ public class IterableExtensionTest {
         assertTrue("Iterable should support user attribute changes", eventTypes.contains(Event.Type.USER_ATTRIBUTE_CHANGE));
         assertTrue("Iterable should support user identity changes", eventTypes.contains(Event.Type.USER_IDENTITY_CHANGE));
 
-        Setting setting = response.getAudienceProcessingRegistration().getAudienceSubscriptionSettings().get(0);
+        Setting setting = response.getAudienceProcessingRegistration().getAudienceConnectionSettings().get(0);
         assertTrue("Iterable audiences should have a single Integer setting", setting.getType().equals(Setting.Type.INTEGER));
     }
 
@@ -214,12 +214,8 @@ public class IterableExtensionTest {
         userIdentities.add(new UserIdentity(UserIdentity.Type.CUSTOMER, Identity.Encoding.RAW, "123456"));
         eventProcessingRequest.setUserIdentities(userIdentities);
         event.setContext(new Event.Context(eventProcessingRequest));
-        JSONObject iterableObject = new JSONObject();
-        iterableObject.put("campaignId", 12345);
-        iterableObject.put("templateId", 54321);
-        JSONObject payload = new JSONObject();
-        payload.put("itbl", iterableObject);
-        event.setPayload(payload.toString());
+
+        event.setPayload("{\"itbl\":{\"campaignId\":12345, \"templateId\":54321}}");
 
         long timeStamp = System.currentTimeMillis();
         event.setTimestamp(timeStamp);

--- a/iterable-java-sdk/src/main/java/com/mparticle/iterable/IterableService.java
+++ b/iterable-java-sdk/src/main/java/com/mparticle/iterable/IterableService.java
@@ -33,6 +33,9 @@ public interface IterableService {
     @POST("api/users/update")
     Call<IterableApiResponse> userUpdate(@Body UserUpdateRequest trackRequest);
 
+    @POST("api/users/updateEmail")
+    Call<IterableApiResponse> updateEmail(@Body UpdateEmailRequest updateEmailRequest);
+
     @POST("api/users/registerDeviceToken")
     Call<IterableApiResponse> registerToken(@Body RegisterDeviceTokenRequest registerRequest);
 

--- a/iterable-java-sdk/src/main/java/com/mparticle/iterable/TrackRequest.java
+++ b/iterable-java-sdk/src/main/java/com/mparticle/iterable/TrackRequest.java
@@ -22,7 +22,7 @@ public class TrackRequest {
     /**
      *  Additional data associated with event (i.e. item id, item amount),
      */
-    public Map<String, String> dataFields;
+    public Map<String, Object> dataFields;
     /**
      * userId that was passed into the updateUser call
      */


### PR DESCRIPTION
This PR addresses 3 issues/requests for the Iterable integration:

1. When there is no email present, use a special XXX@placeholder.email ID. The Iterable registration has also been updated to make email optional, and to add several device ID and the device application stamp to use for this placeholder generation.
2. For the log-in and sign-up scenario, where a user goes from not having an email identity to having an email identity, update the email from the placeholder email to the new email. This PR also covers the email change scenario.
3. To a best-effort parse of event attributes into booleans, doubles, ints, and strings prior to uploading.