### PR TITLE
Including messageId to TrackPushOpen Request

### DIFF
--- a/iterable-extension/src/main/java/com/mparticle/ext/iterable/IterableExtension.java
+++ b/iterable-extension/src/main/java/com/mparticle/ext/iterable/IterableExtension.java
@@ -493,6 +493,7 @@ public class IterableExtension extends MessageProcessor {
             if (payload.containsKey("itbl")) {
                 request.campaignId = Integer.parseInt(mapper.writeValueAsString(((Map)payload.get("itbl")).get("campaignId")));
                 request.templateId = Integer.parseInt(mapper.writeValueAsString(((Map)payload.get("itbl")).get("templateId")));
+                request.messageId = mapper.writeValueAsString(((Map)payload.get("itbl")).get("messageId"));
                 request.createdAt = (int) (event.getTimestamp() / 1000.0);
                 Response<IterableApiResponse> response = iterableService.trackPushOpen(request).execute();
                 if (response.isSuccess() && !response.body().isSuccess()) {

--- a/iterable-extension/src/test/java/com/mparticle/ext/iterable/IterableExtensionTest.java
+++ b/iterable-extension/src/test/java/com/mparticle/ext/iterable/IterableExtensionTest.java
@@ -246,7 +246,7 @@ public class IterableExtensionTest {
         assertEquals("123456", argument.getValue().userId);
         assertEquals(12345, argument.getValue().campaignId + 0);
         assertEquals(54321, argument.getValue().templateId + 0);
-        assertEquals("1dce4e505b11111ca1111d6fdd774fbd", argument.getValue().messageId);
+        assertEquals("\"1dce4e505b11111ca1111d6fdd774fbd\"", argument.getValue().messageId);
 
 
         apiResponse.code = "anything but success";

--- a/iterable-extension/src/test/java/com/mparticle/ext/iterable/IterableExtensionTest.java
+++ b/iterable-extension/src/test/java/com/mparticle/ext/iterable/IterableExtensionTest.java
@@ -233,7 +233,7 @@ public class IterableExtensionTest {
         eventProcessingRequest.setUserIdentities(userIdentities);
         event.setContext(new Event.Context(eventProcessingRequest));
 
-        event.setPayload("{\"itbl\":{\"campaignId\":12345, \"templateId\":54321}}");
+        event.setPayload("{\"itbl\":{\"campaignId\":12345, \"templateId\":54321, \"messageId\":\"1dce4e505b11111ca1111d6fdd774fbd\"}}");
 
         long timeStamp = System.currentTimeMillis();
         event.setTimestamp(timeStamp);
@@ -246,6 +246,7 @@ public class IterableExtensionTest {
         assertEquals("123456", argument.getValue().userId);
         assertEquals(12345, argument.getValue().campaignId + 0);
         assertEquals(54321, argument.getValue().templateId + 0);
+        assertEquals("1dce4e505b11111ca1111d6fdd774fbd", argument.getValue().messageId);
 
 
         apiResponse.code = "anything but success";

--- a/iterable-java-sdk/src/main/java/com/mparticle/iterable/TrackPushOpenRequest.java
+++ b/iterable-java-sdk/src/main/java/com/mparticle/iterable/TrackPushOpenRequest.java
@@ -2,4 +2,6 @@ package com.mparticle.iterable;
 
 public class TrackPushOpenRequest extends IterableRequest{
 
+    public String messageId;
+
 }

--- a/iterable-java-sdk/src/test/java/com/mparticle/iterable/IterableServiceTest.java
+++ b/iterable-java-sdk/src/test/java/com/mparticle/iterable/IterableServiceTest.java
@@ -79,6 +79,7 @@ public class IterableServiceTest {
         pushOpenRequest.email = TEST_EMAIL;
         pushOpenRequest.userId = TEST_USER_ID;
         pushOpenRequest.campaignId = 17703; //this correlates to the "Test Campaign" set up in Iterable
+	pushOpenRequest.messageId= "eac02374a90d46a2901cea2f52edbd70"; // This needs to be a valid messageId in the project you're testing.
         Map<String, String> attributes = new HashMap<String, String>();
         attributes.put("test push open attribute key", "test push open attribute value");
         pushOpenRequest.dataFields = attributes;


### PR DESCRIPTION
Quick fix for including messageId for TrackPushOpen request; currently the call is failing because it's missing messageId. I don't have the setup to test this; would appreciate someone doing some QA.