### PR TITLE
Add custom update subscription events

### DIFF
--- a/iterable-extension/build.gradle
+++ b/iterable-extension/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compile (
             'com.amazonaws:aws-lambda-java-core:1.2.0',
             'com.amazonaws:aws-lambda-java-events:2.0.2',
-            'com.mparticle:java-sdk:1.4.0'
+            'com.mparticle:java-sdk:1.8.0'
     )
     compile project(':iterable-java-sdk')
     testCompile('junit:junit:4.12')

--- a/iterable-java-sdk/src/main/java/com/mparticle/iterable/IterableService.java
+++ b/iterable-java-sdk/src/main/java/com/mparticle/iterable/IterableService.java
@@ -12,7 +12,6 @@ import retrofit2.http.GET;
 import retrofit2.http.POST;
 import retrofit2.http.Query;
 
-import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -25,7 +24,7 @@ public interface IterableService {
 
     String HOST = "api.iterable.com";
     String PARAM_API_KEY = "api_key";
-    long SERVICE_TIMEOUT_MILLIS = 300;
+    long SERVICE_TIMEOUT_MILLIS = 500;
 
     @POST("api/events/track")
     Call<IterableApiResponse> track(@Query(IterableService.PARAM_API_KEY) String apiKey, @Body TrackRequest trackRequest);
@@ -52,7 +51,7 @@ public interface IterableService {
     Call<IterableApiResponse> trackPurchase(@Query(IterableService.PARAM_API_KEY) String apiKey, @Body TrackPurchaseRequest purchaseRequest);
 
     @POST("api/users/updateSubscriptions")
-    Call<IterableApiResponse> updateSubscriptions(@Query(IterableService.PARAM_API_KEY) String apiKey, @Body UserUpdateRequest userUpdateRequest);
+    Call<IterableApiResponse> updateSubscriptions(@Query(IterableService.PARAM_API_KEY) String apiKey, @Body UpdateSubscriptionsRequest userUpdateRequest);
 
     /**
      * At the moment this is only used for unit testing the list subscribe/unsubscribe API calls

--- a/iterable-java-sdk/src/main/java/com/mparticle/iterable/IterableService.java
+++ b/iterable-java-sdk/src/main/java/com/mparticle/iterable/IterableService.java
@@ -51,6 +51,9 @@ public interface IterableService {
     @POST("api/commerce/trackPurchase")
     Call<IterableApiResponse> trackPurchase(@Query(IterableService.PARAM_API_KEY) String apiKey, @Body TrackPurchaseRequest purchaseRequest);
 
+    @POST("api/users/updateSubscriptions")
+    Call<IterableApiResponse> updateSubscriptions(@Query(IterableService.PARAM_API_KEY) String apiKey, @Body UserUpdateRequest userUpdateRequest);
+
     /**
      * At the moment this is only used for unit testing the list subscribe/unsubscribe API calls
      */

--- a/iterable-java-sdk/src/main/java/com/mparticle/iterable/UpdateSubscriptionsRequest.java
+++ b/iterable-java-sdk/src/main/java/com/mparticle/iterable/UpdateSubscriptionsRequest.java
@@ -1,0 +1,12 @@
+package com.mparticle.iterable;
+
+import java.util.List;
+
+public class UpdateSubscriptionsRequest {
+    public String email;
+    public List<Integer> emailListIds;
+    public List<Integer> unsubscribedChannelIds;
+    public List<Integer> unsubscribedMessageTypeIds;
+    public Integer campaignId;
+    public Integer templateId;
+}

--- a/iterable-java-sdk/src/main/java/com/mparticle/iterable/UserUpdateRequest.java
+++ b/iterable-java-sdk/src/main/java/com/mparticle/iterable/UserUpdateRequest.java
@@ -4,6 +4,6 @@ import java.util.Map;
 
 public class UserUpdateRequest {
     public String email;
-    public Map<String, String> dataFields;
+    public Map<String, Object> dataFields;
     public String userId;
 }

--- a/iterable-java-sdk/src/main/java/com/mparticle/iterable/UserUpdateRequest.java
+++ b/iterable-java-sdk/src/main/java/com/mparticle/iterable/UserUpdateRequest.java
@@ -4,6 +4,6 @@ import java.util.Map;
 
 public class UserUpdateRequest {
     public String email;
-    public Map<String, Object> dataFields;
+    public Map<String, String> dataFields;
     public String userId;
 }

--- a/iterable-java-sdk/src/test/java/com/mparticle/iterable/IterableServiceTest.java
+++ b/iterable-java-sdk/src/test/java/com/mparticle/iterable/IterableServiceTest.java
@@ -1,14 +1,13 @@
 package com.mparticle.iterable;
 
 import org.junit.Before;
+import org.junit.Test;
 import org.mockito.Mockito;
 import retrofit2.Call;
 import retrofit2.Response;
 
 import java.math.BigDecimal;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.Map;
+import java.util.*;
 
 import static org.junit.Assert.assertTrue;
 
@@ -43,6 +42,8 @@ public class IterableServiceTest {
             Mockito.when(iterableService.trackPushOpen(Mockito.any(), Mockito.any()))
                     .thenReturn(callMock);
             Mockito.when(iterableService.trackPurchase(Mockito.any(), Mockito.any()))
+                    .thenReturn(callMock);
+            Mockito.when(iterableService.updateSubscriptions(Mockito.any(), Mockito.any()))
                     .thenReturn(callMock);
             IterableApiResponse apiResponse = new IterableApiResponse();
             apiResponse.code = IterableApiResponse.SUCCESS_MESSAGE;
@@ -96,7 +97,7 @@ public class IterableServiceTest {
         Map<String, String> attributes = new HashMap<String, String>();
         attributes.put("test attribute key", "test attribute value");
 
-        userUpdateRequest.dataFields = new HashMap<String, Object>(attributes);
+        userUpdateRequest.dataFields = attributes;
         Response<IterableApiResponse> response = iterableService.userUpdate(ITERABLE_API_KEY, userUpdateRequest).execute();
         assertTrue("Retrofit request not successful:\nMessage: " + response.message() + "\nCode: " + response.code(), response.isSuccessful());
         assertTrue("Iterable response was not successful:\n" + response.body().toString(), response.body().isSuccess());
@@ -178,5 +179,18 @@ public class IterableServiceTest {
         Response<IterableApiResponse> response = iterableService.trackPurchase(ITERABLE_API_KEY, request).execute();
         assertTrue("Retrofit request not successful:\nMessage: " + response.message() + "\nCode: " + response.code(), response.isSuccessful());
         assertTrue("Iterable response was not successful:\n" + response.body().toString(), response.body().isSuccess());
+    }
+
+    @Test
+    public void testUpdateSubscriptions() throws Exception {
+        UpdateSubscriptionsRequest request = new UpdateSubscriptionsRequest();
+        request.email = TEST_EMAIL;
+        request.unsubscribedChannelIds = Arrays.asList(1,2,3);
+        request.unsubscribedMessageTypeIds = Arrays.asList(1,2,3);
+        request.emailListIds = Arrays.asList(1,2,3);
+        Response<IterableApiResponse> response = iterableService.updateSubscriptions(ITERABLE_API_KEY, request).execute();
+        assertTrue("Retrofit request not successful:\nMessage: " + response.message() + "\nCode: " + response.code(), response.isSuccessful());
+        assertTrue("Iterable response was not successful:\n" + response.body().toString(), response.body().isSuccess());
+
     }
 }

--- a/iterable-java-sdk/src/test/java/com/mparticle/iterable/IterableServiceTest.java
+++ b/iterable-java-sdk/src/test/java/com/mparticle/iterable/IterableServiceTest.java
@@ -95,7 +95,8 @@ public class IterableServiceTest {
         userUpdateRequest.email = TEST_EMAIL;
         Map<String, String> attributes = new HashMap<String, String>();
         attributes.put("test attribute key", "test attribute value");
-        userUpdateRequest.dataFields = attributes;
+
+        userUpdateRequest.dataFields = new HashMap<String, Object>(attributes);
         Response<IterableApiResponse> response = iterableService.userUpdate(ITERABLE_API_KEY, userUpdateRequest).execute();
         assertTrue("Retrofit request not successful:\nMessage: " + response.message() + "\nCode: " + response.code(), response.isSuccessful());
         assertTrue("Iterable response was not successful:\n" + response.body().toString(), response.body().isSuccess());


### PR DESCRIPTION
This PR does the following:

1. Adds support for Mobile Web.
2. Removes support for User Attribute Update events (this has in fact already been removed in production)
3. Adds support for a Custom Event that triggers an Update Subscriptions API call. As written currently, this event will also be forwarded to Iterable as a regular trackEvent.

The event Custom Event that the function looks for to trigger the API call is as follows:

Event Name:

"updateSubscriptions" (case insensitive)

Optional attributes:
- "emailListIds"
- "unsubscribedChannelIds"
- "unsubscribedMessageTypeIds"
- "campaignId"
- "templateId"